### PR TITLE
Fixed some issues with master object list parsing

### DIFF
--- a/Ds3/ResponseParsers/JobResponseParser.cs
+++ b/Ds3/ResponseParsers/JobResponseParser.cs
@@ -51,7 +51,8 @@ namespace Ds3.ResponseParsers
                 startDate: DateTime.Parse(masterObjectList.AttributeText("StartDate")),
                 chunkOrder: ParseChunkOrdering(masterObjectList.AttributeText("ChunkClientProcessingOrderGuarantee")),
                 nodes: (
-                    from nodeElement in masterObjectList.Element("Nodes").Elements("Node")
+                    from nodesElement in masterObjectList.Elements("Nodes")
+                    from nodeElement in nodesElement.Elements("Node")
                     select new Node(
                         Guid.Parse(nodeElement.AttributeText("Id")),
                         nodeElement.AttributeText("EndPoint"),
@@ -63,7 +64,7 @@ namespace Ds3.ResponseParsers
                     .Elements("Objects")
                     .Select(ParseObjectList)
                     .ToList(),
-                status: ResponseParseUtilities.ParseJobStatus(masterObjectList.TextOfOrNull("Status"))
+                status: ResponseParseUtilities.ParseJobStatus(masterObjectList.AttributeTextOrNull("Status"))
             );
         }
 

--- a/TestDs3/TestData/CompletedMasterObjectList.xml
+++ b/TestDs3/TestData/CompletedMasterObjectList.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<MasterObjectList
+  BucketName="avid-bucket"
+  CachedSizeInBytes="1095132963"
+  ChunkClientProcessingOrderGuarantee="IN_ORDER"
+  CompletedSizeInBytes="0"
+  JobId="350225fb-ec92-4456-a09d-5ffb7c7830bb"
+  OriginalSizeInBytes="1095132963"
+  Priority="NORMAL"
+  RequestType="PUT"
+  StartDate="2015-05-05T17:09:30.000Z"
+  Status="COMPLETED"
+  UserId="0c93db8e-2cbd-4f1c-a313-4d1aa23c08dc"
+  UserName="spectra"
+  WriteOptimization="CAPACITY"/>

--- a/TestDs3/TestDs3.csproj
+++ b/TestDs3/TestDs3.csproj
@@ -136,6 +136,9 @@
     <EmbeddedResource Include="TestData\GetPhysicalPlacementFullDetailsResponse.xml" />
     <EmbeddedResource Include="TestData\GetPhysicalPlacementResponse.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TestData\CompletedMasterObjectList.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/TestDs3/TestDs3Client.cs
+++ b/TestDs3/TestDs3Client.cs
@@ -35,6 +35,7 @@ namespace TestDs3
         private static readonly IDictionary<string, string> _emptyHeaders = new Dictionary<string, string>();
         private static readonly IDictionary<string, string> _emptyQueryParams = new Dictionary<string, string>();
         private const string JobResponseResourceName = "TestDs3.TestData.ResultingMasterObjectList.xml";
+        private const string CompletedJobResponseResourceName = "TestDs3.TestData.CompletedMasterObjectList.xml";
         private const string AllocateJobChunkResponseResourceName = "TestDs3.TestData.AllocateJobChunkResponse.xml";
         private const string GetAvailableJobChunksResponseResourceName = "TestDs3.TestData.GetAvailableJobChunksResponse.xml";
         private const string EmptyGetAvailableJobChunksResponseResourceName = "TestDs3.TestData.EmptyGetAvailableJobChunksResponse.xml";
@@ -314,6 +315,27 @@ namespace TestDs3
                 .Returning(HttpStatusCode.OK, stringResponse, _emptyHeaders)
                 .AsClient;
             CheckJobResponse(client.GetJob(new GetJobRequest(Guid.Parse("1a85e743-ec8f-4789-afec-97e587a26936"))));
+        }
+
+        [Test]
+        public void TestGetCompletedJob()
+        {
+            var stringResponse = ReadResource(CompletedJobResponseResourceName);
+            var client = MockNetwork
+                .Expecting(HttpVerb.GET, "/_rest_/job/350225fb-ec92-4456-a09d-5ffb7c7830bb", _emptyQueryParams, "")
+                .Returning(HttpStatusCode.OK, stringResponse, _emptyHeaders)
+                .AsClient;
+            var jobId = Guid.Parse("350225fb-ec92-4456-a09d-5ffb7c7830bb");
+            var job = client.GetJob(new GetJobRequest(jobId));
+            Assert.AreEqual("avid-bucket", job.BucketName);
+            Assert.AreEqual(ChunkOrdering.InOrder, job.ChunkOrder);
+            Assert.AreEqual(jobId, job.JobId);
+            CollectionAssert.AreEqual(Enumerable.Empty<Node>(), job.Nodes);
+            CollectionAssert.AreEqual(Enumerable.Empty<JobObjectList>(), job.ObjectLists);
+            Assert.AreEqual("NORMAL", job.Priority);
+            Assert.AreEqual("PUT", job.RequestType);
+            Assert.AreEqual(new DateTime(2015, 5, 5, 17, 9, 30, 0, DateTimeKind.Utc), job.StartDate.ToUniversalTime());
+            Assert.AreEqual(JobStatus.COMPLETED, job.Status);
         }
 
         private static string ReadResource(string resourceName)


### PR DESCRIPTION
* We were checking for an element rather than an attribute for the
  status.
* We threw an exception when there were no "Nodes" elements, which there
  are not for a completed job.