### PR TITLE
Changed $ operator to old fashoined string.Format()

### DIFF
--- a/Ds3/Runtime/Network.cs
+++ b/Ds3/Runtime/Network.cs
@@ -145,15 +145,15 @@ namespace Ds3.Runtime
                 switch (request.ChecksumType)
                 {
                     case Checksum.ChecksumType.Md5:
-                        if (sdkNetworkSwitch.TraceVerbose) Trace.WriteLine($"MD5 checksum is {chucksumValue}");
+                        if (sdkNetworkSwitch.TraceVerbose) Trace.WriteLine(@"MD5 checksum is {chucksumValue}");
                         httpRequest.Headers.Add(HttpHeaders.ContentMd5, chucksumValue);
                         break;
                     case Checksum.ChecksumType.Sha256:
-                        if (sdkNetworkSwitch.TraceVerbose) Trace.WriteLine($"SHA-256 checksum is {chucksumValue}");
+                        if (sdkNetworkSwitch.TraceVerbose) Trace.WriteLine(@"SHA-256 checksum is {chucksumValue}");
                         httpRequest.Headers.Add(HttpHeaders.ContentSha256, chucksumValue);
                         break;
                     case Checksum.ChecksumType.Sha512:
-                        if (sdkNetworkSwitch.TraceVerbose) Trace.WriteLine($"SHA-512 checksum is {chucksumValue}");
+                        if (sdkNetworkSwitch.TraceVerbose) Trace.WriteLine(@"SHA-512 checksum is {chucksumValue}");
                         httpRequest.Headers.Add(HttpHeaders.ContentSha512, chucksumValue);
                         break;
                 }


### PR DESCRIPTION
Hey, any objections? This doesn't build in VS2012 or the version of mono I am testing on. It's a promising new syntax, but I think we need to be more backwards-compatible.

