### PR TITLE
Add Dockerfile for ds3_net_sdk

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM mono:latest
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y git make
+
+ADD run_tests.sh /opt/
+
+ENTRYPOINT ["/opt/run_tests.sh"]

--- a/Docker/run_docker.rb
+++ b/Docker/run_docker.rb
@@ -1,0 +1,54 @@
+require "faraday"
+require "json"
+
+# Has to be to https and not http.  Insert your blackpearl box.
+connection = Faraday.new(:url => "https://sm2u-11-mgmt.eng.sldomain.com",
+                         # Don't worry about verifying the SSL certificate.
+                         # In a production system, you'd want to verify it but
+                         # it doesn't matter for the cucumber tests.
+                         :ssl => { :verify => false }) do |conn|
+  conn.request(:basic_auth, "spectra", "spectra")
+  # User Ruby's net/http library
+  conn.adapter(:net_http)
+  # Setup for JSON requests and responses.  You could insert your own
+  # middleware to handle the JSON parsing and encoding, which is what
+  # SpectraView does.  This example just manually takes care of that down below.
+  conn.headers = { "Accept" => "application/json",
+                   "Content-Type" => "application/json" }
+end
+
+# List all users
+response = connection.get("/users")
+# All GET responses are under a root "data"
+users = JSON.parse(response.body)["data"]
+
+spectra_user = {}
+users.each do | user_entry |
+  spectra_user = user_entry if user_entry["name"].eql?("Spectra")
+end
+
+# None of the "/users" responses include the S3 keys.  For that, you have to
+# make a separate "/s3v/keys" request which is setup to return an array
+# of S3 authid/secretkey pairs in case we ever allow more than one pair per
+# user.
+response = connection.get("/s3v/keys?user_id=#{spectra_user["id"]}")
+spectra_user_keys = JSON.parse(response.body)["data"][0]
+
+ENV["DOCKER_REPO"] = ENV["DOCKER_REPO"] || "denverm80/spectra_sandbox"
+ENV["DS3_ENDPOINT"] = "http://sm2u-11.eng.sldomain.com"
+ENV["DS3_SECRET_KEY"] = spectra_user_keys["secret_key"]
+ENV["DS3_ACCESS_KEY"] = spectra_user_keys["auth_id"]
+puts "DS3_ENDPOINT #{ENV["DS3_ENDPOINT"]}"
+puts "DS3_SECRET_KEY #{ENV["DS3_SECRET_KEY"]}"
+puts "DS3_ACCESS_KEY #{ENV["DS3_ACCESS_KEY"]}"
+puts "DOCKER_REPO #{ENV["DOCKER_REPO"]}"
+puts "GIT_REPO #{ENV["GIT_REPO"] || "default"}"
+
+puts "docker run -e DS3_ENDPOINT -e DS3_SECRET_KEY -e DS3_ACCESS_KEY -e GIT_REPO -it --dns=10.1.0.9 #{ENV["DOCKER_REPO"]}"
+output = `docker run -e DS3_ENDPOINT -e DS3_SECRET_KEY -e DS3_ACCESS_KEY -e GIT_REPO -it --dns=10.1.0.9 #{ENV["DOCKER_REPO"]}`
+docker_status = $?
+
+puts output
+puts "docker status[#{docker_status}][#{docker_status.exitstatus}]"
+exit docker_status.exitstatus
+

--- a/Docker/run_tests.sh
+++ b/Docker/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-${GIT_REPO:=https://github.com/SpectraLogic/ds3_net_sdk.git}
+echo using Git Repo: ${GIT_REPO:="https://github.com/SpectraLogic/ds3_net_sdk.git"}
 
 # clone ds3_net_sdk from github
 cd /opt

--- a/Docker/run_tests.sh
+++ b/Docker/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+${GIT_REPO:=https://github.com/SpectraLogic/ds3_net_sdk.git}
+
+# clone ds3_net_sdk from github
+cd /opt
+git clone $GIT_REPO
+cd ds3_net_sdk
+make test
+


### PR DESCRIPTION
Also modified run_docker.rb and run_tests.sh to allow the GIT_REPO and DOCKER_REPO environment variables to supercede defaults if provided.  Once this is approved / merged I will make similar changes to the other Jenkins SDK tasks.



denverm@dm-lt:~/code/github/ds3_net_sdk/Docker$ export DOCKER_REPO=f759e0e9046b
denverm@dm-lt:~/code/github/ds3_net_sdk/Docker$ ruby run_docker.rb
DS3_ENDPOINT http://sm2u-11.eng.sldomain.com
DS3_SECRET_KEY VwGw33gN
DS3_ACCESS_KEY c3BlY3RyYQ==
DOCKER_REPO f759e0e9046b
GIT_REPO default
docker run -e DS3_ENDPOINT -e DS3_SECRET_KEY -e DS3_ACCESS_KEY -e GIT_REPO -it --dns=10.1.0.9 f759e0e9046b
using Git Repo: https://github.com/SpectraLogic/ds3_net_sdk.git
Cloning into 'ds3_net_sdk'...
remote: Counting objects: 4737, done.
remote: Compressing objects: 100% (17/17), done.
remote: Total 4737 (delta 5), reused 0 (delta 0), pack-reused 4720
Receiving objects: 100% (4737/4737), 9.23 MiB | 6.10 MiB/s, done.
Resolving deltas: 100% (3612/3612), done.
xbuild /p:Configuration=Debug ds3_net_sdk.sln
XBuild Engine Version 12.0
Mono, Version 4.0.4.0
Copyright (C) 2005-2013 Various Mono authors

Build started 10/21/2015 16:55:04.
__________________________________________________
Project "/opt/ds3_net_sdk/ds3_net_sdk.sln" (default target(s)):
	Target ValidateSolutionConfiguration:
.
.
.
mono ./packages/NUnit.Runners.2.6.3/tools/nunit-console.exe ./TestDs3/bin/Debug/TestDs3.dll
WARNING: The runtime version supported by this application is unavailable.
Using default runtime: v4.0.30319
NUnit-Console version 2.6.3.13283
Copyright (C) 2002-2012 Charlie Poole.
Copyright (C) 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov.
Copyright (C) 2000-2002 Philip Craig.
All Rights Reserved.

Runtime Environment - 
   OS Version: Unix 3.13.0.36
  CLR Version: 4.0.30319.17020 ( Mono 4.0 ( 4.0.4 (Stable 4.0.4.1/5ab4c0d Tue Aug 25 23:11:51 UTC 2015) ) )

ProcessModel: Default    DomainUsage: Single
Execution Runtime: mono-4.0
..................................................................................................................................................
Tests run: 146, Errors: 0, Failures: 0, Inconclusive: 0, Time: 2.7169893 seconds
  Not run: 0, Invalid: 0, Ignored: 0, Skipped: 0

mono ./packages/NUnit.Runners.2.6.3/tools/nunit-console.exe ./IntegrationTestDS3/bin/Debug/IntegrationTestDS3.dll
WARNING: The runtime version supported by this application is unavailable.
Using default runtime: v4.0.30319
NUnit-Console version 2.6.3.13283
Copyright (C) 2002-2012 Charlie Poole.
Copyright (C) 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov.
Copyright (C) 2000-2002 Philip Craig.
All Rights Reserved.

Runtime Environment - 
   OS Version: Unix 3.13.0.36
  CLR Version: 4.0.30319.17020 ( Mono 4.0 ( 4.0.4 (Stable 4.0.4.1/5ab4c0d Tue Aug 25 23:11:51 UTC 2015) ) )

ProcessModel: Default    DomainUsage: Single
Execution Runtime: mono-4.0
........
Tests run: 8, Errors: 0, Failures: 0, Inconclusive: 0, Time: 3.3591326 seconds
  Not run: 0, Invalid: 0, Ignored: 0, Skipped: 0

docker status[pid 10119 exit 0][0]
denverm@dm-lt:~/code/github/ds3_net_sdk/Docker$ 




********************************************************************************************************************



denverm@dm-lt:~/code/github/ds3_net_sdk/Docker$ export GIT_REPO=https://github.com/DenverM80/ds3_net_sdk.git
denverm@dm-lt:~/code/github/ds3_net_sdk/Docker$ 
denverm@dm-lt:~/code/github/ds3_net_sdk/Docker$ 
denverm@dm-lt:~/code/github/ds3_net_sdk/Docker$ ruby run_docker.rb
DS3_ENDPOINT http://sm2u-11.eng.sldomain.com
DS3_SECRET_KEY VwGw33gN
DS3_ACCESS_KEY c3BlY3RyYQ==
DOCKER_REPO f759e0e9046b
GIT_REPO https://github.com/DenverM80/ds3_net_sdk.git
docker run -e DS3_ENDPOINT -e DS3_SECRET_KEY -e DS3_ACCESS_KEY -e GIT_REPO -it --dns=10.1.0.9 f759e0e9046b
using Git Repo: https://github.com/DenverM80/ds3_net_sdk.git
Cloning into 'ds3_net_sdk'...
remote: Counting objects: 4731, done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 4731 (delta 1), reused 0 (delta 0), pack-reused 4720
Receiving objects: 100% (4731/4731), 9.23 MiB | 7.31 MiB/s, done.
Resolving deltas: 100% (3608/3608), done.
xbuild /p:Configuration=Debug ds3_net_sdk.sln
XBuild Engine Version 12.0
Mono, Version 4.0.4.0
Copyright (C) 2005-2013 Various Mono authors

Build started 10/21/2015 19:20:23.
__________________________________________________
Project "/opt/ds3_net_sdk/ds3_net_sdk.sln" (default target(s)):
.
.
.
Time Elapsed 00:00:02.1307930
mono ./packages/NUnit.Runners.2.6.3/tools/nunit-console.exe ./TestDs3/bin/Debug/TestDs3.dll
WARNING: The runtime version supported by this application is unavailable.
Using default runtime: v4.0.30319
NUnit-Console version 2.6.3.13283
Copyright (C) 2002-2012 Charlie Poole.
Copyright (C) 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov.
Copyright (C) 2000-2002 Philip Craig.
All Rights Reserved.

Runtime Environment - 
   OS Version: Unix 3.13.0.36
  CLR Version: 4.0.30319.17020 ( Mono 4.0 ( 4.0.4 (Stable 4.0.4.1/5ab4c0d Tue Aug 25 23:11:51 UTC 2015) ) )

ProcessModel: Default    DomainUsage: Single
Execution Runtime: mono-4.0
..................................................................................................................................................
Tests run: 146, Errors: 0, Failures: 0, Inconclusive: 0, Time: 2.7188192 seconds
  Not run: 0, Invalid: 0, Ignored: 0, Skipped: 0

mono ./packages/NUnit.Runners.2.6.3/tools/nunit-console.exe ./IntegrationTestDS3/bin/Debug/IntegrationTestDS3.dll
WARNING: The runtime version supported by this application is unavailable.
Using default runtime: v4.0.30319
NUnit-Console version 2.6.3.13283
Copyright (C) 2002-2012 Charlie Poole.
Copyright (C) 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov.
Copyright (C) 2000-2002 Philip Craig.
All Rights Reserved.

Runtime Environment - 
   OS Version: Unix 3.13.0.36
  CLR Version: 4.0.30319.17020 ( Mono 4.0 ( 4.0.4 (Stable 4.0.4.1/5ab4c0d Tue Aug 25 23:11:51 UTC 2015) ) )

ProcessModel: Default    DomainUsage: Single
Execution Runtime: mono-4.0
........
Tests run: 8, Errors: 0, Failures: 0, Inconclusive: 0, Time: 3.7851905 seconds
  Not run: 0, Invalid: 0, Ignored: 0, Skipped: 0

docker status[pid 11146 exit 0][0]
denverm@dm-lt:~/code/github/ds3_net_sdk/Docker$ 


