### PR TITLE
Counting objects in test was checking antefolder twice instead of postfolder

### DIFF
--- a/Ds3/Models/DS3GetObjectsInfo.cs
+++ b/Ds3/Models/DS3GetObjectsInfo.cs
@@ -7,7 +7,6 @@ namespace Ds3.Models
 {
     public class DS3GetObjectsInfo : Ds3Object
     {
-        public string Name { get; private set; }
         public string Id { get; private set; }
         public string BucketId { get; private set; }
         public DateTime CreationDate { get; private set; }
@@ -23,7 +22,6 @@ namespace Ds3.Models
             string type,
             Int64 version) : base(name, null)
         {
-            this.Name = name;
             this.CreationDate = creationDate;
             this.BucketId = bucketId;
             this.Id = id;

--- a/IntegrationTestDS3/IntegrationTestDS3Client.cs
+++ b/IntegrationTestDS3/IntegrationTestDS3Client.cs
@@ -476,7 +476,7 @@ namespace IntegrationTestDs3
             job.Transfer(FileHelpers.BuildFileGetter(testDirectoryDestPrefix, PREFIX));
 
             var postfolder = FileHelpers.ListObjectsForDirectory(testDirectoryDestPrefix, PREFIX);
-            int postfoldercount = antefolder.Count();
+            int postfoldercount = postfolder.Count();
             Assert.Greater(postfoldercount, antefoldercount);
         }
 
@@ -494,7 +494,7 @@ namespace IntegrationTestDs3
             job.Transfer(FileHelpers.BuildFileGetter(testDirectoryDest, string.Empty));
 
             var postfolder = FileHelpers.ListObjectsForDirectory(testDirectoryDest, string.Empty);
-            int postfoldercount = antefolder.Count();
+            int postfoldercount = postfolder.Count();
             Assert.Greater(postfoldercount, antefoldercount);
         }
 


### PR DESCRIPTION
It is IEnumerale so it works, computing .Count() each time, but the fix clarifies.