### PR TITLE
Support HTTPS

### DIFF
--- a/Ds3/Ds3.csproj
+++ b/Ds3/Ds3.csproj
@@ -1006,6 +1006,7 @@
     <Compile Include="Runtime\Ds3ContentLengthNotMatch.cs" />
     <Compile Include="Runtime\Ds3NoMoreRetransmitException.cs" />
     <Compile Include="Runtime\Ds3NotSupportedStream.cs" />
+    <Compile Include="Runtime\Ds3ServerCertificateValidation.cs" />
     <Compile Include="Runtime\IWebRequest.cs" />
     <Compile Include="Runtime\Ds3WebRequest.cs" />
     <Compile Include="Runtime\Ds3WebStream.cs" />
@@ -1083,6 +1084,7 @@
     <Compile Include="Runtime\INetwork.cs" />
     <Compile Include="Runtime\IWebResponse.cs" />
     <Compile Include="Runtime\Network.cs" />
+    <Compile Include="Runtime\RuntimeUtils.cs" />
     <Compile Include="Runtime\S3Signer.cs" />
     <Compile Include="Runtime\Ds3WebResponse.cs" />
     <Compile Include="Runtime\XmlExtensions.cs" />

--- a/Ds3/Ds3Builder.cs
+++ b/Ds3/Ds3Builder.cs
@@ -146,6 +146,11 @@ namespace Ds3
         /// <returns></returns>
         public IDs3Client Build()
         {
+            if (IsHttpsScheme() && RuntimeUtils.IsRunningOnMono())
+            {
+                throw new Exception(Resources.HttpsNotSupportedOnMono);
+            }
+
             var netLayer = new Network(
                 _endpoint,
                 _creds,
@@ -160,6 +165,11 @@ namespace Ds3
                 netLayer.Proxy = _proxy;
             }
             return new Ds3Client(netLayer);
+        }
+
+        private bool IsHttpsScheme()
+        {
+            return _endpoint.Scheme.ToLower().Equals("https");
         }
     }
 }

--- a/Ds3/Resources.Designer.cs
+++ b/Ds3/Resources.Designer.cs
@@ -178,6 +178,15 @@ namespace Ds3 {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to HTTPS requests are not supported on Mono..
+        /// </summary>
+        internal static string HttpsNotSupportedOnMono {
+            get {
+                return ResourceManager.GetString("HttpsNotSupportedOnMono", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enum value not accounted for in a switch statement intended to be exhaustive..
         /// </summary>
         internal static string InvalidEnumValueException {

--- a/Ds3/Resources.resx
+++ b/Ds3/Resources.resx
@@ -222,4 +222,7 @@
   <data name="NotSupportedStream" xml:space="preserve">
     <value>Non seekable stream are not supported for PUTs retransmit</value>
   </data>
+  <data name="HttpsNotSupportedOnMono" xml:space="preserve">
+    <value>HTTPS requests are not supported on Mono.</value>
+  </data>
 </root>

--- a/Ds3/Runtime/Ds3ServerCertificateValidation.cs
+++ b/Ds3/Runtime/Ds3ServerCertificateValidation.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+using System.Net;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Ds3.Runtime
+{
+    public static class Ds3ServerCertificateValidation
+    {
+        public static void OverrideValidation()
+        {
+            //Adding Tls11 and Tls12 to the exsiting Security Protocol to support HTTPS requests
+            ServicePointManager.SecurityProtocol |= (SecurityProtocolType)SslProtocols.Tls11 |
+                                                    (SecurityProtocolType)SslProtocols.Tls12;
+
+            //Adding Server Certificate Validation
+            ServicePointManager.ServerCertificateValidationCallback = Validator;
+        }
+
+        private static bool Validator(object sender, X509Certificate certificate, X509Chain chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            return true;
+        }
+    }
+}

--- a/Ds3/Runtime/Network.cs
+++ b/Ds3/Runtime/Network.cs
@@ -89,6 +89,8 @@ namespace Ds3.Runtime
                     if (SdkNetworkSwitch.TraceInfo) { Trace.WriteLine(string.Format(Resources.RequestLogging, request.GetType())); }
                     if (SdkNetworkSwitch.TraceVerbose) { Trace.WriteLine(request.getDescription(BuildQueryParams(request.QueryParams))); }
 
+                    Ds3ServerCertificateValidation.OverrideValidation();
+
                     var ds3WebRequest = _createDs3WebRequestFunc(request, content);
                     try
                     {

--- a/Ds3/Runtime/RuntimeUtils.cs
+++ b/Ds3/Runtime/RuntimeUtils.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+using System;
 
 namespace Ds3.Runtime
 {

--- a/Ds3/Runtime/RuntimeUtils.cs
+++ b/Ds3/Runtime/RuntimeUtils.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Ds3.Runtime
+{
+    public static class RuntimeUtils
+    {
+        public static bool IsRunningOnMono()
+        {
+            return Type.GetType("Mono.Runtime") != null;
+        }
+    }
+}

--- a/IntegrationTestDS3/IntegrationTestDS3Client.cs
+++ b/IntegrationTestDS3/IntegrationTestDS3Client.cs
@@ -1388,7 +1388,7 @@ namespace IntegrationTestDs3
         [Test]
         public void TestHttpsClient()
         {
-            if (RuntimeUtils.IsRunningOnMono()) return;
+            if (RuntimeUtils.IsRunningOnMono()) Assert.Ignore();
 
             var endpoint = Environment.GetEnvironmentVariable("DS3_ENDPOINT");
             endpoint = endpoint.ToLower().Replace("http://", "https://");

--- a/IntegrationTestDS3/IntegrationTestDS3Client.cs
+++ b/IntegrationTestDS3/IntegrationTestDS3Client.cs
@@ -1384,5 +1384,28 @@ namespace IntegrationTestDs3
                 Ds3TestUtils.DeleteBucket(_client, bucketName);
             }
         }
+
+        [Test]
+        public void TestHttpsClient()
+        {
+            if (RuntimeUtils.IsRunningOnMono()) return;
+
+            var endpoint = Environment.GetEnvironmentVariable("DS3_ENDPOINT");
+            endpoint = endpoint.ToLower().Replace("http://", "https://");
+            var accesskey = Environment.GetEnvironmentVariable("DS3_ACCESS_KEY");
+            var secretkey = Environment.GetEnvironmentVariable("DS3_SECRET_KEY");
+            var proxy = Environment.GetEnvironmentVariable("http_proxy");
+
+            var credentials = new Credentials(accesskey, secretkey);
+            var builder = new Ds3Builder(endpoint, credentials);
+            if (!string.IsNullOrEmpty(proxy))
+            {
+                builder.WithProxy(new Uri(proxy));
+            }
+
+            var client = builder.Build();
+
+            client.GetService(new GetServiceRequest());
+        }
     }
 }


### PR DESCRIPTION
Tests result on mono:

Runtime Environment
   OS Version: Linux 3.16.0.4
  CLR Version: 4.0.30319.42000

Test Files
    ./TestDs3/bin/Release/TestDs3.dll


Run Settings
    WorkDirectory: /home/spectra/sharon_ds3_new_sdk
    ImageRuntimeVersion: 4.0.30319
    ImageTargetFrameworkName: .NETFramework,Version=v4.5.2
    ImageRequiresX86: False
    ImageRequiresDefaultAppDomainAssemblyResolver: False
    NumberOfTestWorkers: 16

Test Run Summary
  Overall result: Passed
  Test Count: 230, Passed: 230, Failed: 0, Inconclusive: 0, Skipped: 0
  Start time: 2016-10-11 17:58:09Z
    End time: 2016-10-11 17:58:14Z
    Duration: 4.647 seconds

Results (nunit3) saved as TestResult.xml
mono ./packages/NUnit.ConsoleRunner.3.4.1/tools/nunit3-console.exe ./IntegrationTestDS3/bin/Release/IntegrationTestDS3.dll
NUnit Console Runner 3.4.1
Copyright (C) 2016 Charlie Poole

Runtime Environment
   OS Version: Linux 3.16.0.4
  CLR Version: 4.0.30319.42000

Test Files
    ./IntegrationTestDS3/bin/Release/IntegrationTestDS3.dll

=> IntegrationTestDs3.IntegrationTestDs3Client.TestPutObjectWithMaxBlob


Tests Not Run

1) Ignored : IntegrationTestDs3.IntegrationTestDs3Client.TestHttpsClient


2) Ignored : IntegrationTestDs3.IntegrationTestDs3Client.TestPutWithChecksum


3) Ignored : IntegrationTestDs3.IntegrationTestDs3Client.TestPutWithSuppliedChecksum


Run Settings
    WorkDirectory: /home/spectra/sharon_ds3_new_sdk
    ImageRuntimeVersion: 4.0.30319
    ImageTargetFrameworkName: .NETFramework,Version=v4.5.2
    ImageRequiresX86: False
    ImageRequiresDefaultAppDomainAssemblyResolver: False
    NumberOfTestWorkers: 16

Test Run Summary
  Overall result: Warning
  Test Count: 38, Passed: 35, Failed: 0, Inconclusive: 0, Skipped: 3
    Skipped Tests - Ignored: 3, Explicit: 0, Other: 0
  Start time: 2016-10-11 17:58:15Z
    End time: 2016-10-11 17:58:53Z
    Duration: 37.279 seconds