### PR TITLE
Removed objects list constructor param from EjectStorageDomainSpectraS3Request

### DIFF
--- a/Ds3/Calls/EjectStorageDomainSpectraS3Request.cs
+++ b/Ds3/Calls/EjectStorageDomainSpectraS3Request.cs
@@ -15,12 +15,8 @@
 
 // This code is auto-generated, do not modify
 using Ds3.Models;
-using Ds3.Runtime;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Xml.Linq;
+using System.Net;
 
 namespace Ds3.Calls
 {
@@ -28,8 +24,6 @@ namespace Ds3.Calls
     {
         
         public string StorageDomainId { get; private set; }
-
-        public IEnumerable<Ds3Object> Objects { get; private set; }
 
         
         private string _bucketId;
@@ -114,48 +108,25 @@ namespace Ds3.Calls
         }
 
 
-        public EjectStorageDomainSpectraS3Request(IEnumerable<Ds3Object> objects, Guid storageDomainId) {
+        
+        
+        public EjectStorageDomainSpectraS3Request(Guid storageDomainId)
+        {
             this.StorageDomainId = storageDomainId.ToString();
-            this.Objects = objects.ToList();
             this.QueryParams.Add("operation", "eject");
             
             this.QueryParams.Add("storage_domain_id", storageDomainId.ToString());
 
-            if (!objects.ToList().TrueForAll(obj => obj.Size.HasValue))
-            {
-                throw new Ds3RequestException(Resources.ObjectsMissingSizeException);
-            }
         }
-        public EjectStorageDomainSpectraS3Request(IEnumerable<Ds3Object> objects, string storageDomainId) {
+
+        
+        public EjectStorageDomainSpectraS3Request(string storageDomainId)
+        {
             this.StorageDomainId = storageDomainId;
-            this.Objects = objects.ToList();
             this.QueryParams.Add("operation", "eject");
             
             this.QueryParams.Add("storage_domain_id", storageDomainId);
 
-            if (!objects.ToList().TrueForAll(obj => obj.Size.HasValue))
-            {
-                throw new Ds3RequestException(Resources.ObjectsMissingSizeException);
-            }
-        }
-
-        internal override Stream GetContentStream()
-        {
-            return new XDocument()
-                .AddFluent(
-                    new XElement("Objects").AddAllFluent(
-                        from obj in this.Objects
-                        select new XElement("Object")
-                            .SetAttributeValueFluent("Name", obj.Name)
-                            .SetAttributeValueFluent("Size", obj.Size.Value.ToString("D"))
-                    )
-                )
-                .WriteToMemoryStream();
-        }
-
-        internal override long GetContentLength()
-        {
-            return GetContentStream().Length;
         }
 
         internal override HttpVerb Verb

--- a/Ds3/Calls/GetDs3TargetReadPreferencesSpectraS3Request.cs
+++ b/Ds3/Calls/GetDs3TargetReadPreferencesSpectraS3Request.cs
@@ -59,8 +59,8 @@ namespace Ds3.Calls
             set { WithPageStartMarker(value); }
         }
 
-        private TargetReadPreference? _readPreference;
-        public TargetReadPreference? ReadPreference
+        private TargetReadPreferenceType? _readPreference;
+        public TargetReadPreferenceType? ReadPreference
         {
             get { return _readPreference; }
             set { WithReadPreference(value); }
@@ -179,7 +179,7 @@ namespace Ds3.Calls
         }
 
         
-        public GetDs3TargetReadPreferencesSpectraS3Request WithReadPreference(TargetReadPreference? readPreference)
+        public GetDs3TargetReadPreferencesSpectraS3Request WithReadPreference(TargetReadPreferenceType? readPreference)
         {
             this._readPreference = readPreference;
             if (readPreference != null)

--- a/Ds3/Calls/GetDs3TargetsSpectraS3Request.cs
+++ b/Ds3/Calls/GetDs3TargetsSpectraS3Request.cs
@@ -66,8 +66,8 @@ namespace Ds3.Calls
             set { WithDataPathVerifyCertificate(value); }
         }
 
-        private TargetReadPreference? _defaultReadPreference;
-        public TargetReadPreference? DefaultReadPreference
+        private TargetReadPreferenceType? _defaultReadPreference;
+        public TargetReadPreferenceType? DefaultReadPreference
         {
             get { return _defaultReadPreference; }
             set { WithDefaultReadPreference(value); }
@@ -220,7 +220,7 @@ namespace Ds3.Calls
         }
 
         
-        public GetDs3TargetsSpectraS3Request WithDefaultReadPreference(TargetReadPreference? defaultReadPreference)
+        public GetDs3TargetsSpectraS3Request WithDefaultReadPreference(TargetReadPreferenceType? defaultReadPreference)
         {
             this._defaultReadPreference = defaultReadPreference;
             if (defaultReadPreference != null)

--- a/Ds3/Calls/ModifyDs3TargetSpectraS3Request.cs
+++ b/Ds3/Calls/ModifyDs3TargetSpectraS3Request.cs
@@ -82,8 +82,8 @@ namespace Ds3.Calls
             set { WithDataPathVerifyCertificate(value); }
         }
 
-        private TargetReadPreference? _defaultReadPreference;
-        public TargetReadPreference? DefaultReadPreference
+        private TargetReadPreferenceType? _defaultReadPreference;
+        public TargetReadPreferenceType? DefaultReadPreference
         {
             get { return _defaultReadPreference; }
             set { WithDefaultReadPreference(value); }
@@ -238,7 +238,7 @@ namespace Ds3.Calls
         }
 
         
-        public ModifyDs3TargetSpectraS3Request WithDefaultReadPreference(TargetReadPreference? defaultReadPreference)
+        public ModifyDs3TargetSpectraS3Request WithDefaultReadPreference(TargetReadPreferenceType? defaultReadPreference)
         {
             this._defaultReadPreference = defaultReadPreference;
             if (defaultReadPreference != null)

--- a/Ds3/Calls/PairBackRegisteredDs3TargetSpectraS3Request.cs
+++ b/Ds3/Calls/PairBackRegisteredDs3TargetSpectraS3Request.cs
@@ -82,8 +82,8 @@ namespace Ds3.Calls
             set { WithDataPathVerifyCertificate(value); }
         }
 
-        private TargetReadPreference? _defaultReadPreference;
-        public TargetReadPreference? DefaultReadPreference
+        private TargetReadPreferenceType? _defaultReadPreference;
+        public TargetReadPreferenceType? DefaultReadPreference
         {
             get { return _defaultReadPreference; }
             set { WithDefaultReadPreference(value); }
@@ -231,7 +231,7 @@ namespace Ds3.Calls
         }
 
         
-        public PairBackRegisteredDs3TargetSpectraS3Request WithDefaultReadPreference(TargetReadPreference? defaultReadPreference)
+        public PairBackRegisteredDs3TargetSpectraS3Request WithDefaultReadPreference(TargetReadPreferenceType? defaultReadPreference)
         {
             this._defaultReadPreference = defaultReadPreference;
             if (defaultReadPreference != null)

--- a/Ds3/Calls/PutDs3TargetReadPreferenceSpectraS3Request.cs
+++ b/Ds3/Calls/PutDs3TargetReadPreferenceSpectraS3Request.cs
@@ -25,7 +25,7 @@ namespace Ds3.Calls
         
         public string BucketId { get; private set; }
 
-        public TargetReadPreference ReadPreference { get; private set; }
+        public TargetReadPreferenceType ReadPreference { get; private set; }
 
         public string TargetId { get; private set; }
 
@@ -33,7 +33,7 @@ namespace Ds3.Calls
 
         
         
-        public PutDs3TargetReadPreferenceSpectraS3Request(Guid bucketId, TargetReadPreference readPreference, Guid targetId)
+        public PutDs3TargetReadPreferenceSpectraS3Request(Guid bucketId, TargetReadPreferenceType readPreference, Guid targetId)
         {
             this.BucketId = bucketId.ToString();
             this.ReadPreference = readPreference;
@@ -48,7 +48,7 @@ namespace Ds3.Calls
         }
 
         
-        public PutDs3TargetReadPreferenceSpectraS3Request(string bucketId, TargetReadPreference readPreference, string targetId)
+        public PutDs3TargetReadPreferenceSpectraS3Request(string bucketId, TargetReadPreferenceType readPreference, string targetId)
         {
             this.BucketId = bucketId;
             this.ReadPreference = readPreference;

--- a/Ds3/Calls/RegisterDs3TargetSpectraS3Request.cs
+++ b/Ds3/Calls/RegisterDs3TargetSpectraS3Request.cs
@@ -67,8 +67,8 @@ namespace Ds3.Calls
             set { WithDataPathVerifyCertificate(value); }
         }
 
-        private TargetReadPreference? _defaultReadPreference;
-        public TargetReadPreference? DefaultReadPreference
+        private TargetReadPreferenceType? _defaultReadPreference;
+        public TargetReadPreferenceType? DefaultReadPreference
         {
             get { return _defaultReadPreference; }
             set { WithDefaultReadPreference(value); }
@@ -164,7 +164,7 @@ namespace Ds3.Calls
         }
 
         
-        public RegisterDs3TargetSpectraS3Request WithDefaultReadPreference(TargetReadPreference? defaultReadPreference)
+        public RegisterDs3TargetSpectraS3Request WithDefaultReadPreference(TargetReadPreferenceType? defaultReadPreference)
         {
             this._defaultReadPreference = defaultReadPreference;
             if (defaultReadPreference != null)

--- a/Ds3/Ds3.csproj
+++ b/Ds3/Ds3.csproj
@@ -772,7 +772,7 @@
     <Compile Include="Models\TapePartitionFailureType.cs" />
     <Compile Include="Models\TapePartitionList.cs" />
     <Compile Include="Models\TapePartitionState.cs" />
-    <Compile Include="Models\TargetReadPreference.cs" />
+    <Compile Include="Models\TargetReadPreferenceType.cs" />
     <Compile Include="Models\TargetState.cs" />
     <Compile Include="Models\UnavailableMediaUsagePolicy.cs" />
     <Compile Include="Models\User.cs" />

--- a/Ds3/Models/Ds3Target.cs
+++ b/Ds3/Models/Ds3Target.cs
@@ -30,7 +30,7 @@ namespace Ds3.Models
         public int? DataPathPort { get; set; }
         public string DataPathProxy { get; set; }
         public bool DataPathVerifyCertificate { get; set; }
-        public TargetReadPreference DefaultReadPreference { get; set; }
+        public TargetReadPreferenceType DefaultReadPreference { get; set; }
         public Guid Id { get; set; }
         public string Name { get; set; }
         public bool PermitGoingOutOfSync { get; set; }

--- a/Ds3/Models/Ds3TargetReadPreference.cs
+++ b/Ds3/Models/Ds3TargetReadPreference.cs
@@ -24,7 +24,7 @@ namespace Ds3.Models
     {
         public Guid BucketId { get; set; }
         public Guid Id { get; set; }
-        public TargetReadPreference ReadPreference { get; set; }
+        public TargetReadPreferenceType ReadPreference { get; set; }
         public Guid TargetId { get; set; }
     }
 }

--- a/Ds3/Models/TargetReadPreferenceType.cs
+++ b/Ds3/Models/TargetReadPreferenceType.cs
@@ -17,7 +17,7 @@
 
 namespace Ds3.Models
 {
-    public enum TargetReadPreference
+    public enum TargetReadPreferenceType
     {
         MINIMUM_LATENCY,
         AFTER_ONLINE_POOL,

--- a/Ds3/ResponseParsers/ModelParsers.cs
+++ b/Ds3/ResponseParsers/ModelParsers.cs
@@ -1124,7 +1124,7 @@ namespace Ds3.ResponseParsers
                 DataPathPort = ParseNullableInt(element.Element("DataPathPort")),
                 DataPathProxy = ParseNullableString(element.Element("DataPathProxy")),
                 DataPathVerifyCertificate = ParseBool(element.Element("DataPathVerifyCertificate")),
-                DefaultReadPreference = ParseTargetReadPreference(element.Element("DefaultReadPreference")),
+                DefaultReadPreference = ParseTargetReadPreferenceType(element.Element("DefaultReadPreference")),
                 Id = ParseGuid(element.Element("Id")),
                 Name = ParseNullableString(element.Element("Name")),
                 PermitGoingOutOfSync = ParseBool(element.Element("PermitGoingOutOfSync")),
@@ -1164,7 +1164,7 @@ namespace Ds3.ResponseParsers
             {
                 BucketId = ParseGuid(element.Element("BucketId")),
                 Id = ParseGuid(element.Element("Id")),
-                ReadPreference = ParseTargetReadPreference(element.Element("ReadPreference")),
+                ReadPreference = ParseTargetReadPreferenceType(element.Element("ReadPreference")),
                 TargetId = ParseGuid(element.Element("TargetId"))
             };
         }
@@ -3416,30 +3416,30 @@ namespace Ds3.ResponseParsers
         {
             return ParseDs3TargetFailureType(element.Value);
         }
-        public static TargetReadPreference? ParseNullableTargetReadPreference(string targetReadPreferenceOrNull)
+        public static TargetReadPreferenceType? ParseNullableTargetReadPreferenceType(string targetReadPreferenceTypeOrNull)
         {
-            return string.IsNullOrWhiteSpace(targetReadPreferenceOrNull)
-                ? (TargetReadPreference?) null
-                : ParseTargetReadPreference(targetReadPreferenceOrNull);
+            return string.IsNullOrWhiteSpace(targetReadPreferenceTypeOrNull)
+                ? (TargetReadPreferenceType?) null
+                : ParseTargetReadPreferenceType(targetReadPreferenceTypeOrNull);
         }
 
-        public static TargetReadPreference ParseTargetReadPreference(string targetReadPreference)
+        public static TargetReadPreferenceType ParseTargetReadPreferenceType(string targetReadPreferenceType)
         {
-            return ParseEnumType<TargetReadPreference>(targetReadPreference);
+            return ParseEnumType<TargetReadPreferenceType>(targetReadPreferenceType);
         }
 
-        public static TargetReadPreference? ParseNullableTargetReadPreference(XElement element)
+        public static TargetReadPreferenceType? ParseNullableTargetReadPreferenceType(XElement element)
         {
             if (null == element)
             {
                 return null;
             }
-            return ParseNullableTargetReadPreference(element.Value);
+            return ParseNullableTargetReadPreferenceType(element.Value);
         }
 
-        public static TargetReadPreference ParseTargetReadPreference(XElement element)
+        public static TargetReadPreferenceType ParseTargetReadPreferenceType(XElement element)
         {
-            return ParseTargetReadPreference(element.Value);
+            return ParseTargetReadPreferenceType(element.Value);
         }
         public static TargetState? ParseNullableTargetState(string targetStateOrNull)
         {


### PR DESCRIPTION
**Changed**
- Removed object list constructor param from EjectStorageDomainSpectraS3Request handler
- Renamed `TargetReadPreference` -> `TargetReadPreferenceType`