### PR TITLE
downgrade the .NET version to 4.5.1

### DIFF
--- a/Ds3/Ds3.csproj
+++ b/Ds3/Ds3.csproj
@@ -23,7 +23,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ds3</RootNamespace>
     <AssemblyName>ds3_net_sdk</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/VersionInfo.cs
+++ b/VersionInfo.cs
@@ -26,5 +26,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("3.2.6.0")]
-[assembly: AssemblyFileVersion("3.2.6.0")]
+[assembly: AssemblyVersion("3.2.7.0")]
+[assembly: AssemblyFileVersion("3.2.7.0")]


### PR DESCRIPTION
Mono Testing results:
Runtime Environment
   OS Version: Linux 3.16.0.4
  CLR Version: 4.0.30319.42000

Test Files
    ./TestDs3/bin/Release/TestDs3.dll


Run Settings
    WorkDirectory: /home/spectra/sharon_ds3_new_sdk
    ImageRuntimeVersion: 4.0.30319
    ImageTargetFrameworkName: .NETFramework,Version=v4.5.2
    ImageRequiresX86: False
    ImageRequiresDefaultAppDomainAssemblyResolver: False
    NumberOfTestWorkers: 16

Test Run Summary
  Overall result: Passed
  Test Count: 230, Passed: 230, Failed: 0, Inconclusive: 0, Skipped: 0
  Start time: 2016-10-19 16:56:47Z
    End time: 2016-10-19 16:56:52Z
    Duration: 4.736 seconds

Results (nunit3) saved as TestResult.xml
mono ./packages/NUnit.ConsoleRunner.3.4.1/tools/nunit3-console.exe ./IntegrationTestDS3/bin/Release/IntegrationTestDS3.dll
NUnit Console Runner 3.4.1
Copyright (C) 2016 Charlie Poole

Runtime Environment
   OS Version: Linux 3.16.0.4
  CLR Version: 4.0.30319.42000

Test Files
    ./IntegrationTestDS3/bin/Release/IntegrationTestDS3.dll

=> IntegrationTestDs3.IntegrationTestDs3Client.TestPutObjectWithMaxBlob


Tests Not Run

1) Ignored : IntegrationTestDs3.IntegrationTestDs3Client.TestHttpsClient


2) Ignored : IntegrationTestDs3.IntegrationTestDs3Client.TestPutWithChecksum


3) Ignored : IntegrationTestDs3.IntegrationTestDs3Client.TestPutWithSuppliedChecksum


Run Settings
    WorkDirectory: /home/spectra/sharon_ds3_new_sdk
    ImageRuntimeVersion: 4.0.30319
    ImageTargetFrameworkName: .NETFramework,Version=v4.5.2
    ImageRequiresX86: False
    ImageRequiresDefaultAppDomainAssemblyResolver: False
    NumberOfTestWorkers: 16

Test Run Summary
  Overall result: Warning
  Test Count: 38, Passed: 35, Failed: 0, Inconclusive: 0, Skipped: 3
    Skipped Tests - Ignored: 3, Explicit: 0, Other: 0
  Start time: 2016-10-19 16:56:53Z
    End time: 2016-10-19 16:57:30Z
    Duration: 37.244 seconds
