### PR TITLE
Disable the warning for Missing 'XML comment for publicly visible typ…

### DIFF
--- a/Ds3/Ds3.csproj
+++ b/Ds3/Ds3.csproj
@@ -49,6 +49,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>bin\Release\ds3_net_sdk.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
…e or member'