### PR TITLE
Removed redundant conversion of string to string in requests

### DIFF
--- a/Ds3/Calls/AllocateJobChunkSpectraS3Request.cs
+++ b/Ds3/Calls/AllocateJobChunkSpectraS3Request.cs
@@ -56,7 +56,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/job_chunk/" + JobChunkId.ToString();
+                return "/_rest_/job_chunk/" + JobChunkId;
             }
         }
     }

--- a/Ds3/Calls/CancelActiveJobSpectraS3Request.cs
+++ b/Ds3/Calls/CancelActiveJobSpectraS3Request.cs
@@ -58,7 +58,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/active_job/" + ActiveJobId.ToString();
+                return "/_rest_/active_job/" + ActiveJobId;
             }
         }
     }

--- a/Ds3/Calls/CancelEjectTapeSpectraS3Request.cs
+++ b/Ds3/Calls/CancelEjectTapeSpectraS3Request.cs
@@ -56,7 +56,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/CancelFormatTapeSpectraS3Request.cs
+++ b/Ds3/Calls/CancelFormatTapeSpectraS3Request.cs
@@ -56,7 +56,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/CancelImportTapeSpectraS3Request.cs
+++ b/Ds3/Calls/CancelImportTapeSpectraS3Request.cs
@@ -56,7 +56,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/CancelJobSpectraS3Request.cs
+++ b/Ds3/Calls/CancelJobSpectraS3Request.cs
@@ -58,7 +58,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/job/" + JobId.ToString();
+                return "/_rest_/job/" + JobId;
             }
         }
     }

--- a/Ds3/Calls/CancelOnlineTapeSpectraS3Request.cs
+++ b/Ds3/Calls/CancelOnlineTapeSpectraS3Request.cs
@@ -56,7 +56,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/CancelVerifyTapeSpectraS3Request.cs
+++ b/Ds3/Calls/CancelVerifyTapeSpectraS3Request.cs
@@ -56,7 +56,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/CleanTapeDriveSpectraS3Request.cs
+++ b/Ds3/Calls/CleanTapeDriveSpectraS3Request.cs
@@ -56,7 +56,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape_drive/" + TapeDriveId.ToString();
+                return "/_rest_/tape_drive/" + TapeDriveId;
             }
         }
     }

--- a/Ds3/Calls/CloseAggregatingJobSpectraS3Request.cs
+++ b/Ds3/Calls/CloseAggregatingJobSpectraS3Request.cs
@@ -58,7 +58,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/job/" + JobId.ToString();
+                return "/_rest_/job/" + JobId;
             }
         }
     }

--- a/Ds3/Calls/DelegateDeleteUserSpectraS3Request.cs
+++ b/Ds3/Calls/DelegateDeleteUserSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/user/" + UserId.ToString();
+                return "/_rest_/user/" + UserId;
             }
         }
     }

--- a/Ds3/Calls/DeleteDataPersistenceRuleSpectraS3Request.cs
+++ b/Ds3/Calls/DeleteDataPersistenceRuleSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/data_persistence_rule/" + DataPersistenceRuleId.ToString();
+                return "/_rest_/data_persistence_rule/" + DataPersistenceRuleId;
             }
         }
     }

--- a/Ds3/Calls/DeleteDataPolicySpectraS3Request.cs
+++ b/Ds3/Calls/DeleteDataPolicySpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/data_policy/" + DataPolicyId.ToString();
+                return "/_rest_/data_policy/" + DataPolicyId;
             }
         }
     }

--- a/Ds3/Calls/DeletePermanentlyLostTapeSpectraS3Request.cs
+++ b/Ds3/Calls/DeletePermanentlyLostTapeSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/DeleteTapeDriveSpectraS3Request.cs
+++ b/Ds3/Calls/DeleteTapeDriveSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape_drive/" + TapeDriveId.ToString();
+                return "/_rest_/tape_drive/" + TapeDriveId;
             }
         }
     }

--- a/Ds3/Calls/EjectTapeSpectraS3Request.cs
+++ b/Ds3/Calls/EjectTapeSpectraS3Request.cs
@@ -100,7 +100,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/FormatTapeSpectraS3Request.cs
+++ b/Ds3/Calls/FormatTapeSpectraS3Request.cs
@@ -78,7 +78,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/GetActiveJobSpectraS3Request.cs
+++ b/Ds3/Calls/GetActiveJobSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/active_job/" + ActiveJobId.ToString();
+                return "/_rest_/active_job/" + ActiveJobId;
             }
         }
     }

--- a/Ds3/Calls/GetBlobsOnTapeSpectraS3Request.cs
+++ b/Ds3/Calls/GetBlobsOnTapeSpectraS3Request.cs
@@ -88,7 +88,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/GetDataPersistenceRuleSpectraS3Request.cs
+++ b/Ds3/Calls/GetDataPersistenceRuleSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/data_persistence_rule/" + DataPersistenceRuleId.ToString();
+                return "/_rest_/data_persistence_rule/" + DataPersistenceRuleId;
             }
         }
     }

--- a/Ds3/Calls/GetDataPolicySpectraS3Request.cs
+++ b/Ds3/Calls/GetDataPolicySpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/data_policy/" + DataPolicyId.ToString();
+                return "/_rest_/data_policy/" + DataPolicyId;
             }
         }
     }

--- a/Ds3/Calls/GetJobChunkSpectraS3Request.cs
+++ b/Ds3/Calls/GetJobChunkSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/job_chunk/" + JobChunkId.ToString();
+                return "/_rest_/job_chunk/" + JobChunkId;
             }
         }
     }

--- a/Ds3/Calls/GetJobSpectraS3Request.cs
+++ b/Ds3/Calls/GetJobSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/job/" + JobId.ToString();
+                return "/_rest_/job/" + JobId;
             }
         }
     }

--- a/Ds3/Calls/GetJobToReplicateSpectraS3Request.cs
+++ b/Ds3/Calls/GetJobToReplicateSpectraS3Request.cs
@@ -58,7 +58,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/job/" + JobId.ToString();
+                return "/_rest_/job/" + JobId;
             }
         }
     }

--- a/Ds3/Calls/GetTapeDriveSpectraS3Request.cs
+++ b/Ds3/Calls/GetTapeDriveSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape_drive/" + TapeDriveId.ToString();
+                return "/_rest_/tape_drive/" + TapeDriveId;
             }
         }
     }

--- a/Ds3/Calls/GetTapeLibrarySpectraS3Request.cs
+++ b/Ds3/Calls/GetTapeLibrarySpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape_library/" + TapeLibraryId.ToString();
+                return "/_rest_/tape_library/" + TapeLibraryId;
             }
         }
     }

--- a/Ds3/Calls/GetTapeSpectraS3Request.cs
+++ b/Ds3/Calls/GetTapeSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/GetUserSpectraS3Request.cs
+++ b/Ds3/Calls/GetUserSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/user/" + UserId.ToString();
+                return "/_rest_/user/" + UserId;
             }
         }
     }

--- a/Ds3/Calls/ImportTapeSpectraS3Request.cs
+++ b/Ds3/Calls/ImportTapeSpectraS3Request.cs
@@ -255,7 +255,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/InspectTapeSpectraS3Request.cs
+++ b/Ds3/Calls/InspectTapeSpectraS3Request.cs
@@ -78,7 +78,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/ModifyActiveJobSpectraS3Request.cs
+++ b/Ds3/Calls/ModifyActiveJobSpectraS3Request.cs
@@ -120,7 +120,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/active_job/" + ActiveJobId.ToString();
+                return "/_rest_/active_job/" + ActiveJobId;
             }
         }
     }

--- a/Ds3/Calls/ModifyDataPersistenceRuleSpectraS3Request.cs
+++ b/Ds3/Calls/ModifyDataPersistenceRuleSpectraS3Request.cs
@@ -120,7 +120,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/data_persistence_rule/" + DataPersistenceRuleId.ToString();
+                return "/_rest_/data_persistence_rule/" + DataPersistenceRuleId;
             }
         }
     }

--- a/Ds3/Calls/ModifyDataPolicySpectraS3Request.cs
+++ b/Ds3/Calls/ModifyDataPolicySpectraS3Request.cs
@@ -340,7 +340,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/data_policy/" + DataPolicyId.ToString();
+                return "/_rest_/data_policy/" + DataPolicyId;
             }
         }
     }

--- a/Ds3/Calls/ModifyJobSpectraS3Request.cs
+++ b/Ds3/Calls/ModifyJobSpectraS3Request.cs
@@ -120,7 +120,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/job/" + JobId.ToString();
+                return "/_rest_/job/" + JobId;
             }
         }
     }

--- a/Ds3/Calls/ModifyTapeDriveSpectraS3Request.cs
+++ b/Ds3/Calls/ModifyTapeDriveSpectraS3Request.cs
@@ -76,7 +76,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape_drive/" + TapeDriveId.ToString();
+                return "/_rest_/tape_drive/" + TapeDriveId;
             }
         }
     }

--- a/Ds3/Calls/ModifyTapeSpectraS3Request.cs
+++ b/Ds3/Calls/ModifyTapeSpectraS3Request.cs
@@ -120,7 +120,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/ModifyUserSpectraS3Request.cs
+++ b/Ds3/Calls/ModifyUserSpectraS3Request.cs
@@ -135,7 +135,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/user/" + UserId.ToString();
+                return "/_rest_/user/" + UserId;
             }
         }
     }

--- a/Ds3/Calls/OnlineTapeSpectraS3Request.cs
+++ b/Ds3/Calls/OnlineTapeSpectraS3Request.cs
@@ -56,7 +56,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/RawImportTapeSpectraS3Request.cs
+++ b/Ds3/Calls/RawImportTapeSpectraS3Request.cs
@@ -123,7 +123,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }

--- a/Ds3/Calls/RegenerateUserSecretKeySpectraS3Request.cs
+++ b/Ds3/Calls/RegenerateUserSecretKeySpectraS3Request.cs
@@ -56,7 +56,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/user/" + UserId.ToString();
+                return "/_rest_/user/" + UserId;
             }
         }
     }

--- a/Ds3/Calls/TruncateActiveJobSpectraS3Request.cs
+++ b/Ds3/Calls/TruncateActiveJobSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/active_job/" + ActiveJobId.ToString();
+                return "/_rest_/active_job/" + ActiveJobId;
             }
         }
     }

--- a/Ds3/Calls/TruncateJobSpectraS3Request.cs
+++ b/Ds3/Calls/TruncateJobSpectraS3Request.cs
@@ -54,7 +54,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/job/" + JobId.ToString();
+                return "/_rest_/job/" + JobId;
             }
         }
     }

--- a/Ds3/Calls/VerifyTapeSpectraS3Request.cs
+++ b/Ds3/Calls/VerifyTapeSpectraS3Request.cs
@@ -78,7 +78,7 @@ namespace Ds3.Calls
         {
             get
             {
-                return "/_rest_/tape/" + TapeId.ToString();
+                return "/_rest_/tape/" + TapeId;
             }
         }
     }


### PR DESCRIPTION
**Changes**
When creating request handlers, all IDs are stored internally as strings. This update removes the redundant conversion of the internally stored IDs (as strings) to strings.