### PR TITLE
Fix for SA-207 and SA-209

### DIFF
--- a/Ds3/Calls/GetBlobsOnAzureTargetSpectraS3Request.cs
+++ b/Ds3/Calls/GetBlobsOnAzureTargetSpectraS3Request.cs
@@ -15,12 +15,8 @@
 
 // This code is auto-generated, do not modify
 using Ds3.Models;
-using Ds3.Runtime;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Xml.Linq;
+using System.Net;
 
 namespace Ds3.Calls
 {
@@ -29,44 +25,15 @@ namespace Ds3.Calls
         
         public string AzureTarget { get; private set; }
 
-        public IEnumerable<Ds3Object> Objects { get; private set; }
-
         
 
         
-        public GetBlobsOnAzureTargetSpectraS3Request(string azureTarget, IEnumerable<Ds3Object> objects) {
+        
+        public GetBlobsOnAzureTargetSpectraS3Request(string azureTarget)
+        {
             this.AzureTarget = azureTarget;
-            this.Objects = objects.ToList();
             this.QueryParams.Add("operation", "get_physical_placement");
             
-        }
-
-        internal override Stream GetContentStream()
-        {
-            return new XDocument()
-                .AddFluent(
-                    new XElement("Objects").AddAllFluent(
-                        from obj in this.Objects
-                        select new XElement("Object")
-                            .SetAttributeValueFluent("Name", obj.Name)
-                            .SetAttributeValueFluent("Size", ToDs3ObjectSize(obj))
-                    )
-                )
-                .WriteToMemoryStream();
-        }
-
-        internal string ToDs3ObjectSize(Ds3Object ds3Object)
-        {
-            if (ds3Object.Size == null)
-            {
-                return null;
-            }
-            return ds3Object.Size.Value.ToString("D");
-        }
-
-        internal override long GetContentLength()
-        {
-            return GetContentStream().Length;
         }
 
         internal override HttpVerb Verb

--- a/Ds3/Calls/GetBlobsOnDs3TargetSpectraS3Request.cs
+++ b/Ds3/Calls/GetBlobsOnDs3TargetSpectraS3Request.cs
@@ -15,12 +15,8 @@
 
 // This code is auto-generated, do not modify
 using Ds3.Models;
-using Ds3.Runtime;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Xml.Linq;
+using System.Net;
 
 namespace Ds3.Calls
 {
@@ -29,44 +25,15 @@ namespace Ds3.Calls
         
         public string Ds3Target { get; private set; }
 
-        public IEnumerable<Ds3Object> Objects { get; private set; }
-
         
 
         
-        public GetBlobsOnDs3TargetSpectraS3Request(string ds3Target, IEnumerable<Ds3Object> objects) {
+        
+        public GetBlobsOnDs3TargetSpectraS3Request(string ds3Target)
+        {
             this.Ds3Target = ds3Target;
-            this.Objects = objects.ToList();
             this.QueryParams.Add("operation", "get_physical_placement");
             
-        }
-
-        internal override Stream GetContentStream()
-        {
-            return new XDocument()
-                .AddFluent(
-                    new XElement("Objects").AddAllFluent(
-                        from obj in this.Objects
-                        select new XElement("Object")
-                            .SetAttributeValueFluent("Name", obj.Name)
-                            .SetAttributeValueFluent("Size", ToDs3ObjectSize(obj))
-                    )
-                )
-                .WriteToMemoryStream();
-        }
-
-        internal string ToDs3ObjectSize(Ds3Object ds3Object)
-        {
-            if (ds3Object.Size == null)
-            {
-                return null;
-            }
-            return ds3Object.Size.Value.ToString("D");
-        }
-
-        internal override long GetContentLength()
-        {
-            return GetContentStream().Length;
         }
 
         internal override HttpVerb Verb

--- a/Ds3/Calls/GetBlobsOnPoolSpectraS3Request.cs
+++ b/Ds3/Calls/GetBlobsOnPoolSpectraS3Request.cs
@@ -15,12 +15,8 @@
 
 // This code is auto-generated, do not modify
 using Ds3.Models;
-using Ds3.Runtime;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Xml.Linq;
+using System.Net;
 
 namespace Ds3.Calls
 {
@@ -29,44 +25,15 @@ namespace Ds3.Calls
         
         public string Pool { get; private set; }
 
-        public IEnumerable<Ds3Object> Objects { get; private set; }
-
         
 
         
-        public GetBlobsOnPoolSpectraS3Request(IEnumerable<Ds3Object> objects, string pool) {
+        
+        public GetBlobsOnPoolSpectraS3Request(string pool)
+        {
             this.Pool = pool;
-            this.Objects = objects.ToList();
             this.QueryParams.Add("operation", "get_physical_placement");
             
-        }
-
-        internal override Stream GetContentStream()
-        {
-            return new XDocument()
-                .AddFluent(
-                    new XElement("Objects").AddAllFluent(
-                        from obj in this.Objects
-                        select new XElement("Object")
-                            .SetAttributeValueFluent("Name", obj.Name)
-                            .SetAttributeValueFluent("Size", ToDs3ObjectSize(obj))
-                    )
-                )
-                .WriteToMemoryStream();
-        }
-
-        internal string ToDs3ObjectSize(Ds3Object ds3Object)
-        {
-            if (ds3Object.Size == null)
-            {
-                return null;
-            }
-            return ds3Object.Size.Value.ToString("D");
-        }
-
-        internal override long GetContentLength()
-        {
-            return GetContentStream().Length;
         }
 
         internal override HttpVerb Verb

--- a/Ds3/Calls/GetBlobsOnS3TargetSpectraS3Request.cs
+++ b/Ds3/Calls/GetBlobsOnS3TargetSpectraS3Request.cs
@@ -15,12 +15,8 @@
 
 // This code is auto-generated, do not modify
 using Ds3.Models;
-using Ds3.Runtime;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Xml.Linq;
+using System.Net;
 
 namespace Ds3.Calls
 {
@@ -29,44 +25,15 @@ namespace Ds3.Calls
         
         public string S3Target { get; private set; }
 
-        public IEnumerable<Ds3Object> Objects { get; private set; }
-
         
 
         
-        public GetBlobsOnS3TargetSpectraS3Request(IEnumerable<Ds3Object> objects, string s3Target) {
+        
+        public GetBlobsOnS3TargetSpectraS3Request(string s3Target)
+        {
             this.S3Target = s3Target;
-            this.Objects = objects.ToList();
             this.QueryParams.Add("operation", "get_physical_placement");
             
-        }
-
-        internal override Stream GetContentStream()
-        {
-            return new XDocument()
-                .AddFluent(
-                    new XElement("Objects").AddAllFluent(
-                        from obj in this.Objects
-                        select new XElement("Object")
-                            .SetAttributeValueFluent("Name", obj.Name)
-                            .SetAttributeValueFluent("Size", ToDs3ObjectSize(obj))
-                    )
-                )
-                .WriteToMemoryStream();
-        }
-
-        internal string ToDs3ObjectSize(Ds3Object ds3Object)
-        {
-            if (ds3Object.Size == null)
-            {
-                return null;
-            }
-            return ds3Object.Size.Value.ToString("D");
-        }
-
-        internal override long GetContentLength()
-        {
-            return GetContentStream().Length;
         }
 
         internal override HttpVerb Verb

--- a/Ds3/Calls/GetBlobsOnTapeSpectraS3Request.cs
+++ b/Ds3/Calls/GetBlobsOnTapeSpectraS3Request.cs
@@ -15,12 +15,8 @@
 
 // This code is auto-generated, do not modify
 using Ds3.Models;
-using Ds3.Runtime;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Xml.Linq;
+using System.Net;
 
 namespace Ds3.Calls
 {
@@ -29,51 +25,23 @@ namespace Ds3.Calls
         
         public string TapeId { get; private set; }
 
-        public IEnumerable<Ds3Object> Objects { get; private set; }
-
         
 
         
-        public GetBlobsOnTapeSpectraS3Request(IEnumerable<Ds3Object> objects, Guid tapeId) {
+        
+        public GetBlobsOnTapeSpectraS3Request(Guid tapeId)
+        {
             this.TapeId = tapeId.ToString();
-            this.Objects = objects.ToList();
             this.QueryParams.Add("operation", "get_physical_placement");
             
         }
 
-        public GetBlobsOnTapeSpectraS3Request(IEnumerable<Ds3Object> objects, string tapeId) {
+        
+        public GetBlobsOnTapeSpectraS3Request(string tapeId)
+        {
             this.TapeId = tapeId;
-            this.Objects = objects.ToList();
             this.QueryParams.Add("operation", "get_physical_placement");
             
-        }
-
-        internal override Stream GetContentStream()
-        {
-            return new XDocument()
-                .AddFluent(
-                    new XElement("Objects").AddAllFluent(
-                        from obj in this.Objects
-                        select new XElement("Object")
-                            .SetAttributeValueFluent("Name", obj.Name)
-                            .SetAttributeValueFluent("Size", ToDs3ObjectSize(obj))
-                    )
-                )
-                .WriteToMemoryStream();
-        }
-
-        internal string ToDs3ObjectSize(Ds3Object ds3Object)
-        {
-            if (ds3Object.Size == null)
-            {
-                return null;
-            }
-            return ds3Object.Size.Value.ToString("D");
-        }
-
-        internal override long GetContentLength()
-        {
-            return GetContentStream().Length;
         }
 
         internal override HttpVerb Verb

--- a/Ds3/Calls/GetBulkJobSpectraS3Request.cs
+++ b/Ds3/Calls/GetBulkJobSpectraS3Request.cs
@@ -14,13 +14,12 @@
  */
 
 // This code is auto-generated, do not modify
+using Ds3.Calls.Util;
 using Ds3.Models;
-using Ds3.Runtime;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Xml.Linq;
 
 namespace Ds3.Calls
 {
@@ -155,8 +154,8 @@ namespace Ds3.Calls
             
         }
 
-        public GetBulkJobSpectraS3Request(string bucketName, List<Ds3Object> objects)
-            : this(bucketName, objects.Select(o => o.Name), Enumerable.Empty<Ds3PartialObject>())
+        public GetBulkJobSpectraS3Request(string bucketName, List<Ds3Object> ds3Objects)
+            : this(bucketName, ds3Objects.Select(o => o.Name), Enumerable.Empty<Ds3PartialObject>())
         {
         }
 
@@ -178,19 +177,7 @@ namespace Ds3.Calls
 
         internal override Stream GetContentStream()
         {
-            var root = new XElement("Objects")
-                .AddAllFluent(
-                    from name in this.FullObjects
-                    select new XElement("Object").SetAttributeValueFluent("Name", name)
-                )
-                .AddAllFluent(
-                    from partial in this.PartialObjects
-                    select new XElement("Object")
-                        .SetAttributeValueFluent("Name", partial.Name)
-                        .SetAttributeValueFluent("Offset", partial.Range.Start.ToString())
-                        .SetAttributeValueFluent("Length", partial.Range.Length.ToString())
-                );
-            return new XDocument().AddFluent(root).WriteToMemoryStream();
+            return RequestPayloadUtil.MarshalFullAndPartialObjects(this.FullObjects, this.PartialObjects);
         }
 
         internal override long GetContentLength()

--- a/Ds3/Calls/Util/RequestPayloadUtil.cs
+++ b/Ds3/Calls/Util/RequestPayloadUtil.cs
@@ -52,6 +52,10 @@ namespace Ds3.Calls.Util
         /// Only the name for the Ds3Objects are marshaled. This is used to marshal
         /// the request payloads for:
         ///   EjectStorageDomainBlobsSpectraS3Request
+        ///   GetPhysicalPlacementForObjectsSpectraS3Request
+        ///   GetPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request
+        ///   VerifyPhysicalPlacementForObjectsSpectraS3Request
+        ///   VerifyPhysicalPlacementForObjectsWithFullDetailsSpectraS3Request
         /// </summary>
         /// <param name="ds3Objects">The Ds3Objects to be marshaled to xml</param>
         /// <returns>Stream containing xml marshaling of Ds3Object names</returns>
@@ -66,6 +70,32 @@ namespace Ds3.Calls.Util
                     )
                 )
                 .WriteToMemoryStream();
+        }
+
+        /// <summary>
+        /// Marshals object names and Ds3PartialObjects into an xml formatted stream.
+        /// This is used to marshal the request payloads for:
+        ///   GetBulkJobSpectraS3Request
+        ///   VerifyBulkJobSpectraS3Request
+        /// </summary>
+        /// <param name="fullObjectNames">List of object names representing full objects to be marshaled to xml</param>
+        /// <param name="ds3PartialObjects">List of Ds3PartialObjects to be marshaled to xml</param>
+        /// <returns>Stream containing xml marshaling of full objects followed by Ds3PartialObjects</returns>
+        public static Stream MarshalFullAndPartialObjects(IEnumerable<string> fullObjectNames, IEnumerable<Ds3PartialObject> ds3PartialObjects)
+        {
+            var root = new XElement("Objects")
+                .AddAllFluent(
+                    from name in fullObjectNames
+                    select new XElement("Object").SetAttributeValueFluent("Name", name)
+                )
+                .AddAllFluent(
+                    from partial in ds3PartialObjects
+                    select new XElement("Object")
+                        .SetAttributeValueFluent("Name", partial.Name)
+                        .SetAttributeValueFluent("Offset", partial.Range.Start.ToString())
+                        .SetAttributeValueFluent("Length", partial.Range.Length.ToString())
+                );
+            return new XDocument().AddFluent(root).WriteToMemoryStream();
         }
     }
 }


### PR DESCRIPTION
**Changes**
- SA-207
  - Updated `VerifyBulkJobSpectraS3Request` constructors to accept proper payload of DsPartialObjects, and also support old constructor and properly marshal Ds3Objects marshaling only the name element.
  - Cleaned up `GetBulkJobSpectraS3Request` by moving stream functionality into util for re-use of marshaling code with `VerifyBulkJobSpectraS3Request`
- SA-209
  - Removed erroneous request payload handling for the following commands:
    - GetBlobsOnAzureTargetSpectraS3Request
    - GetBlobsOnTapeSpectraS3Request
    - GetBlobsOnS3TargetSpectraS3Request
    - GetBlobsOnPoolSpectraS3Request
    - GetBlobsOnDs3TargetSpectraS3Request

**Tests**
All modified request handlers have unit tests verifying expected behavior.