### PR TITLE
Code cleanup for requests with payloads

### DIFF
--- a/Ds3/Calls/AbstractIdsPayloadRequest.cs
+++ b/Ds3/Calls/AbstractIdsPayloadRequest.cs
@@ -13,11 +13,11 @@
  * ****************************************************************************
  */
 
+using Ds3.Runtime;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
-using Ds3.Runtime;
 
 namespace Ds3.Calls
 {
@@ -31,9 +31,9 @@ namespace Ds3.Calls
 
         internal long contentLength;
 
-        public AbstractIdsPayloadRequest(List<string> ids)
+        public AbstractIdsPayloadRequest(IEnumerable<string> ids)
         {
-            this.ids = ids;
+            this.ids = ids.ToList();
         }
 
         internal override Stream GetContentStream()

--- a/Ds3/Calls/ClearSuspectBlobAzureTargetsSpectraS3Request.cs
+++ b/Ds3/Calls/ClearSuspectBlobAzureTargetsSpectraS3Request.cs
@@ -46,11 +46,10 @@ namespace Ds3.Calls
 
 
         
-        public ClearSuspectBlobAzureTargetsSpectraS3Request(List<string> ids) : base(ids)
+        public ClearSuspectBlobAzureTargetsSpectraS3Request(IEnumerable<string> ids) : base(ids)
         {
             
         }
-
 
         internal override HttpVerb Verb
         {

--- a/Ds3/Calls/ClearSuspectBlobPoolsSpectraS3Request.cs
+++ b/Ds3/Calls/ClearSuspectBlobPoolsSpectraS3Request.cs
@@ -46,11 +46,10 @@ namespace Ds3.Calls
 
 
         
-        public ClearSuspectBlobPoolsSpectraS3Request(List<string> ids) : base(ids)
+        public ClearSuspectBlobPoolsSpectraS3Request(IEnumerable<string> ids) : base(ids)
         {
             
         }
-
 
         internal override HttpVerb Verb
         {

--- a/Ds3/Calls/ClearSuspectBlobS3TargetsSpectraS3Request.cs
+++ b/Ds3/Calls/ClearSuspectBlobS3TargetsSpectraS3Request.cs
@@ -46,11 +46,10 @@ namespace Ds3.Calls
 
 
         
-        public ClearSuspectBlobS3TargetsSpectraS3Request(List<string> ids) : base(ids)
+        public ClearSuspectBlobS3TargetsSpectraS3Request(IEnumerable<string> ids) : base(ids)
         {
             
         }
-
 
         internal override HttpVerb Verb
         {

--- a/Ds3/Calls/ClearSuspectBlobTapesSpectraS3Request.cs
+++ b/Ds3/Calls/ClearSuspectBlobTapesSpectraS3Request.cs
@@ -46,11 +46,10 @@ namespace Ds3.Calls
 
 
         
-        public ClearSuspectBlobTapesSpectraS3Request(List<string> ids) : base(ids)
+        public ClearSuspectBlobTapesSpectraS3Request(IEnumerable<string> ids) : base(ids)
         {
             
         }
-
 
         internal override HttpVerb Verb
         {

--- a/Ds3/Calls/DeleteObjectsRequest.cs
+++ b/Ds3/Calls/DeleteObjectsRequest.cs
@@ -14,13 +14,11 @@
  */
 
 // This code is auto-generated, do not modify
+using Ds3.Calls.Util;
 using Ds3.Models;
-using Ds3.Runtime;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Xml.Linq;
 
 namespace Ds3.Calls
 {
@@ -55,6 +53,8 @@ namespace Ds3.Calls
         }
 
 
+        
+        
         public DeleteObjectsRequest(string bucketName, IEnumerable<Ds3Object> objects)
         {
             this.BucketName = bucketName;
@@ -66,14 +66,7 @@ namespace Ds3.Calls
 
         internal override Stream GetContentStream()
         {
-            return new XDocument()
-                .AddFluent(
-                    new XElement("Delete").AddAllFluent(
-                        from curObject in this.Objects
-                        select new XElement("Object").AddFluent(new XElement("Key").SetValueFluent(curObject.Name))
-                    )
-                )
-                .WriteToMemoryStream();
+            return RequestPayloadUtil.MarshalDeleteObjectNames(this.Objects);
         }
 
         internal override long GetContentLength()

--- a/Ds3/Calls/MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request.cs
+++ b/Ds3/Calls/MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request.cs
@@ -46,11 +46,10 @@ namespace Ds3.Calls
 
 
         
-        public MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(List<string> ids) : base(ids)
+        public MarkSuspectBlobAzureTargetsAsDegradedSpectraS3Request(IEnumerable<string> ids) : base(ids)
         {
             
         }
-
 
         internal override HttpVerb Verb
         {

--- a/Ds3/Calls/MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request.cs
+++ b/Ds3/Calls/MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request.cs
@@ -46,11 +46,10 @@ namespace Ds3.Calls
 
 
         
-        public MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(List<string> ids) : base(ids)
+        public MarkSuspectBlobDs3TargetsAsDegradedSpectraS3Request(IEnumerable<string> ids) : base(ids)
         {
             
         }
-
 
         internal override HttpVerb Verb
         {

--- a/Ds3/Calls/MarkSuspectBlobPoolsAsDegradedSpectraS3Request.cs
+++ b/Ds3/Calls/MarkSuspectBlobPoolsAsDegradedSpectraS3Request.cs
@@ -46,11 +46,10 @@ namespace Ds3.Calls
 
 
         
-        public MarkSuspectBlobPoolsAsDegradedSpectraS3Request(List<string> ids) : base(ids)
+        public MarkSuspectBlobPoolsAsDegradedSpectraS3Request(IEnumerable<string> ids) : base(ids)
         {
             
         }
-
 
         internal override HttpVerb Verb
         {

--- a/Ds3/Calls/MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request.cs
+++ b/Ds3/Calls/MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request.cs
@@ -46,11 +46,10 @@ namespace Ds3.Calls
 
 
         
-        public MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(List<string> ids) : base(ids)
+        public MarkSuspectBlobS3TargetsAsDegradedSpectraS3Request(IEnumerable<string> ids) : base(ids)
         {
             
         }
-
 
         internal override HttpVerb Verb
         {

--- a/Ds3/Calls/MarkSuspectBlobTapesAsDegradedSpectraS3Request.cs
+++ b/Ds3/Calls/MarkSuspectBlobTapesAsDegradedSpectraS3Request.cs
@@ -46,11 +46,10 @@ namespace Ds3.Calls
 
 
         
-        public MarkSuspectBlobTapesAsDegradedSpectraS3Request(List<string> ids) : base(ids)
+        public MarkSuspectBlobTapesAsDegradedSpectraS3Request(IEnumerable<string> ids) : base(ids)
         {
             
         }
-
 
         internal override HttpVerb Verb
         {

--- a/Ds3/Calls/PutBulkJobSpectraS3Request.cs
+++ b/Ds3/Calls/PutBulkJobSpectraS3Request.cs
@@ -14,13 +14,11 @@
  */
 
 // This code is auto-generated, do not modify
+using Ds3.Calls.Util;
 using Ds3.Models;
-using Ds3.Runtime;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Xml.Linq;
 
 namespace Ds3.Calls
 {
@@ -218,39 +216,13 @@ namespace Ds3.Calls
 
 
         
-        public PutBulkJobSpectraS3Request(string bucketName, IEnumerable<Ds3Object> objects) {
+        
+        public PutBulkJobSpectraS3Request(string bucketName, IEnumerable<Ds3Object> objects)
+        {
             this.BucketName = bucketName;
             this.Objects = objects.ToList();
             this.QueryParams.Add("operation", "start_bulk_put");
             
-        }
-
-        internal override Stream GetContentStream()
-        {
-            return new XDocument()
-                .AddFluent(
-                    new XElement("Objects").AddAllFluent(
-                        from obj in this.Objects
-                        select new XElement("Object")
-                            .SetAttributeValueFluent("Name", obj.Name)
-                            .SetAttributeValueFluent("Size", ToDs3ObjectSize(obj))
-                    )
-                )
-                .WriteToMemoryStream();
-        }
-
-        internal string ToDs3ObjectSize(Ds3Object ds3Object)
-        {
-            if (ds3Object.Size == null)
-            {
-                return null;
-            }
-            return ds3Object.Size.Value.ToString("D");
-        }
-
-        internal override long GetContentLength()
-        {
-            return GetContentStream().Length;
         }
 
         internal override HttpVerb Verb
@@ -267,6 +239,16 @@ namespace Ds3.Calls
             {
                 return "/_rest_/bucket/" + BucketName;
             }
+        }
+
+        internal override Stream GetContentStream()
+        {
+            return RequestPayloadUtil.MarshalDs3ObjectNameAndSize(this.Objects);
+        }
+
+        internal override long GetContentLength()
+        {
+            return GetContentStream().Length;
         }
     }
 }

--- a/Ds3/Calls/Util/RequestPayloadUtil.cs
+++ b/Ds3/Calls/Util/RequestPayloadUtil.cs
@@ -97,5 +97,62 @@ namespace Ds3.Calls.Util
                 );
             return new XDocument().AddFluent(root).WriteToMemoryStream();
         }
+
+        /// <summary>
+        /// Iterates over a group of Ds3Objects and marshals them into an xml stream
+        /// describing objects to be deleted. Only the name for the Ds3Objects are 
+        /// marshaled. This is used to marshal the request payload for:
+        ///   DeleteObjectsRequest
+        /// </summary>
+        /// <param name="ds3Objects">List of objects to be deleted</param>
+        /// <returns>Stream containing xml marshaling of object names to be deleted</returns>
+        public static Stream MarshalDeleteObjectNames(IEnumerable<Ds3Object> ds3Objects)
+        {
+            return new XDocument()
+                .AddFluent(
+                    new XElement("Delete").AddAllFluent(
+                        from curObject in ds3Objects
+                        select new XElement("Object").AddFluent(new XElement("Key").SetValueFluent(curObject.Name))
+                    )
+                )
+                .WriteToMemoryStream();
+        }
+
+        /// <summary>
+        /// Iterates over a group of Ds3Objects and marshals them into an xml stream
+        /// describing their name and size. This is used to marshal the request payload
+        /// for command:
+        ///   PutBulkJobSpectraS3Request
+        /// </summary>
+        /// <param name="ds3Objects">List of objects being marshaled</param>
+        /// <returns>Stream containing xml marshaling of objects' name and size</returns>
+        public static Stream MarshalDs3ObjectNameAndSize(IEnumerable<Ds3Object> ds3Objects)
+        {
+            return new XDocument()
+                .AddFluent(
+                    new XElement("Objects").AddAllFluent(
+                        from obj in ds3Objects
+                        select new XElement("Object")
+                            .SetAttributeValueFluent("Name", obj.Name)
+                            .SetAttributeValueFluent("Size", ToDs3ObjectSize(obj))
+                    )
+                )
+                .WriteToMemoryStream();
+        }
+
+        /// <summary>
+        /// Retrieves the string representation of a Ds3Object's size, or null if
+        /// it does not have one.
+        /// </summary>
+        /// <param name="ds3Object">The object whose size we are retrieving</param>
+        /// <returns></returns>
+        internal static string ToDs3ObjectSize(Ds3Object ds3Object)
+        {
+            if (ds3Object.Size == null)
+            {
+                return null;
+            }
+            return ds3Object.Size.Value.ToString("D");
+        }
     }
 }


### PR DESCRIPTION
**Changes**
Updated requests with payloads
- Updated `List<>` to `IEnumerable<>` when possible
- Moved marshaling code to `RequestPayloadUtil`
- Removed unused imports
