### PR TITLE
NETSDK-140: Properly retrieving ltfs metadata from responses and added unit tests

### DIFF
--- a/Ds3/ResponseParsers/ResponseParseUtilities.cs
+++ b/Ds3/ResponseParsers/ResponseParseUtilities.cs
@@ -30,8 +30,22 @@ namespace Ds3.ResponseParsers
         {
             return headers
                 .Keys
-                .Where(key => key.StartsWith(HttpHeaders.AwsMetadataPrefix))
-                .ToDictionary(key => key.Substring(HttpHeaders.AwsMetadataPrefix.Length), key => headers[key]);
+                .Where(key => key.StartsWith(HttpHeaders.AwsMetadataPrefix) || 
+                              key.StartsWith(HttpHeaders.LtfsMetadataPrefix))
+                .ToDictionary(NormalizeMetadataKeyName, key => headers[key]);
+        }
+
+        internal static string NormalizeMetadataKeyName(string key)
+        {
+            if (key.StartsWith(HttpHeaders.AwsMetadataPrefix))
+            {
+                return key.Substring(HttpHeaders.AwsMetadataPrefix.Length);
+            }
+            if (key.StartsWith(HttpHeaders.LtfsMetadataPrefix))
+            {
+                return key.Substring(HttpHeaders.LtfsMetadataPrefix.Length);
+            }
+            return key;
         }
 
         internal static JobStatus ParseJobStatus(string jobStatus)

--- a/Ds3/Runtime/HttpHeaders.cs
+++ b/Ds3/Runtime/HttpHeaders.cs
@@ -25,5 +25,6 @@ namespace Ds3.Runtime
         public const string Authorization = "Authorization";
         public const string AwsPrefix = "x-amz-";
         public const string AwsMetadataPrefix = AwsPrefix + "meta-";
+        public const string LtfsMetadataPrefix = "x-spectra-ltfs-";
     }
 }

--- a/TestDs3/ResponseParsers/TestResponseParseUtilities.cs
+++ b/TestDs3/ResponseParsers/TestResponseParseUtilities.cs
@@ -1,0 +1,78 @@
+﻿/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+using System.Collections.Generic;
+using Ds3.Models;
+using Ds3.ResponseParsers;
+using NUnit.Framework;
+
+namespace TestDs3
+{
+    [TestFixture]
+    public class TestResponseParseUtilities
+    {
+        
+        private static readonly Dictionary<string, string> TestHeaders = new Dictionary<string, string>
+        {
+            {"RequestHandler-Version", "1.CF182CD57551902A475553F26582BC78"},
+            {"x-spectra-ltfs-user.headeroffset", "99970"},
+            {"ds3-blob-checksum-offset-0", "NOT_COMPUTED"},
+            {"x-spectra-ltfs-user.guid", "060a2b340101010101010f0013-000000-709e29c2d1e20085-e7610015b2a9-a854"},
+            {"ds3-blob-checksum-type", "MD5"},
+            {"x-amz-request-id", "1462"},
+            {"x-amz-meta-test-metadata", "testData"}
+        };
+
+        [Test]
+        public void ExtractCustomMetadataTest()
+        {
+            var expected = new Dictionary<string, string>
+            {
+                {"test-metadata", "testData"},
+                {"user.headeroffset", "99970"},
+                {"user.guid", "060a2b340101010101010f0013-000000-709e29c2d1e20085-e7610015b2a9-a854"}
+            };
+
+            var result = ResponseParseUtilities.ExtractCustomMetadata(TestHeaders);
+            
+            CollectionAssert.AreEquivalent(expected, result);
+        }
+
+        [Test]
+        public void NormalizeMetadataKeyNameTest()
+        {
+            Assert.AreEqual(ResponseParseUtilities.NormalizeMetadataKeyName("x-amz-meta-test-metadata"), "test-metadata");
+            Assert.AreEqual(ResponseParseUtilities.NormalizeMetadataKeyName("x-spectra-ltfs-user.guid"), "user.guid");
+            Assert.AreEqual(ResponseParseUtilities.NormalizeMetadataKeyName("ds3-blob-checksum-type"), "ds3-blob-checksum-type");
+        }
+
+        [Test]
+        public void ParseJobStatusTest()
+        {
+            Assert.AreEqual(ResponseParseUtilities.ParseJobStatus("COMPLETED"), JobStatus.COMPLETED);
+            Assert.AreEqual(ResponseParseUtilities.ParseJobStatus("CANCELLED"), JobStatus.CANCELED);
+            Assert.AreEqual(ResponseParseUtilities.ParseJobStatus("IN_PROGRESS"), JobStatus.IN_PROGRESS);
+            Assert.AreEqual(ResponseParseUtilities.ParseJobStatus("All other inputs"), JobStatus.IN_PROGRESS);
+        }
+
+        [Test]
+        public void ParseIntHeaderTest()
+        {
+            Assert.IsNull(ResponseParseUtilities.ParseIntHeader("DoesNotExist", TestHeaders));
+            Assert.IsNull(ResponseParseUtilities.ParseIntHeader("RequestHandler-Version", TestHeaders));
+            Assert.AreEqual(ResponseParseUtilities.ParseIntHeader("x-spectra-ltfs-user.headeroffset", TestHeaders), 99970);
+        }
+    }
+}

--- a/TestDs3/TestDs3.csproj
+++ b/TestDs3/TestDs3.csproj
@@ -104,6 +104,7 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <Compile Include="Helpers\Streams\TestResourceStore.cs" />
+    <Compile Include="ResponseParsers\TestResponseParseUtilities.cs" />
     <Compile Include="Runtime\TestHttpHelper.cs" />
     <Compile Include="Helpers\ProgressTrackers\TestJobItemTracker.cs" />
     <Compile Include="HelpersForTest.cs" />


### PR DESCRIPTION
**Changes**
When parsing a response that has metadata, we now retrieve ltfs metadata which is denoted by the prefix `x-spectra-ltfs-` in addition to the already retrieved x-amz metadata. The prefixes are stripped from the metadata keys.

Created unit test for the modified `ExtractCustomMetadata` function, as well as for most utilities located within `ResponseParseUtilities`